### PR TITLE
fix(manage_disks_nas): ensure persistence of templated fstab lines

### DIFF
--- a/roles/manage_disks_nas/tasks/configure_parity_cache.yml
+++ b/roles/manage_disks_nas/tasks/configure_parity_cache.yml
@@ -19,6 +19,7 @@
     path: "{{ parity_mount_path }}/parity{{ '%02d' % (index + 1) }}"
     src: "{{ item }}"
     fstype: ext4
+    opts: "{{ manage_disks_nas_ext4_mount_opts }}"
     state: mounted
   loop: "{{ parity_disks }}"
   loop_control:
@@ -45,6 +46,7 @@
     path: "{{ cache_mount_path }}/cache{{ '%02d' % (index + 1) }}"
     src: "{{ item }}"
     fstype: ext4
+    opts: "{{ manage_disks_nas_ext4_mount_opts }}"
     state: mounted
   loop: "{{ cache_disks }}"
   loop_control:

--- a/roles/manage_disks_nas/tasks/configure_subvolume_mount.yml
+++ b/roles/manage_disks_nas/tasks/configure_subvolume_mount.yml
@@ -26,7 +26,7 @@
     path: "{{ data_mount_path }}/data{{ '%02d' % (index + 1) }}"
     src: "{{ item }}"
     fstype: btrfs
-    opts: subvol=data
+    opts: "{{ manage_disks_nas_btrfs_mount_opts }}"
     state: mounted
   loop: "{{ data_disks }}"
   loop_control:

--- a/roles/manage_disks_nas/templates/btrfs_subvolume_mounts.j2
+++ b/roles/manage_disks_nas/templates/btrfs_subvolume_mounts.j2
@@ -1,3 +1,3 @@
 {% for disk in data_disks %}
-{{ disk }} /mnt/data-disks/data{{ '%02d' % loop.index }} btrfs subvol=data,nofail 0 0
+{{ disk }} /mnt/data-disks/data{{ '%02d' % loop.index }} btrfs {{ manage_disks_nas_btrfs_mount_opts }} 0 0
 {% endfor %}

--- a/roles/manage_disks_nas/templates/cache_mounts.j2
+++ b/roles/manage_disks_nas/templates/cache_mounts.j2
@@ -1,3 +1,3 @@
 {% for disk in cache_disks %}
-{{ disk }} {{ cache_mount_path }}/cache{{ '%02d' % loop.index }} ext4 defaults,nofail 0 0
+{{ disk }} {{ cache_mount_path }}/cache{{ '%02d' % loop.index }} ext4 {{ manage_disks_nas_ext4_mount_opts }} 0 0
 {% endfor %}

--- a/roles/manage_disks_nas/templates/parity_mounts.j2
+++ b/roles/manage_disks_nas/templates/parity_mounts.j2
@@ -1,3 +1,3 @@
 {% for disk in parity_disks %}
-{{ disk }} {{ parity_mount_path }}/parity{{ '%02d' % loop.index }} ext4 defaults,nofail 0 0
+{{ disk }} {{ parity_mount_path }}/parity{{ '%02d' % loop.index }} ext4 {{ manage_disks_nas_ext4_mount_opts }} 0 0
 {% endfor %}

--- a/roles/manage_disks_nas/vars/main.yml
+++ b/roles/manage_disks_nas/vars/main.yml
@@ -5,3 +5,6 @@ partition_path: >-
   else device + partition if device.startswith('/dev/sd')
   else null | mandatory('Only /dev/nvme* and /dev/sd* device paths are supported')
   }}
+
+manage_disks_nas_btrfs_mount_opts: subvol=data,nofail
+manage_disks_nas_ext4_mount_opts: defaults,nofail


### PR DESCRIPTION
Ansible's `mount` module will rewrite fstab with the specified options in the `opts` parameter when the `state` parameter is `mounted`.

To avoid rewriting fstab with an incorrect/different option set, the options for both btrfs & ext4 mounts are moved to a variable and then referenced in both the fstab template and the `opts` parameter in relevant instances of the `mount` module.