### PR TITLE
chore: bump pinned / pin unpinned dependencies

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 roles:
   - name: stefangweichinger.ansible_rclone
   - name: geerlingguy.docker
-    version: 7.0.1
+    version: 7.3.0
 
 collections:
   - name: community.general

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,12 @@
 ---
 roles:
   - name: stefangweichinger.ansible_rclone
+    version: 0.2.0
   - name: geerlingguy.docker
     version: 7.3.0
 
 collections:
   - name: community.general
+    version: 9.3.0
   - name: vladgh.samba
+    version: 3.4.0


### PR DESCRIPTION
### Bumped

* actions/checkout v3 -> v4
* actions/setup-python v4 -> v5
* geerlingguy.docker 7.0.1 -> 7.3.0
  Changes are notable but not breaking — most changes are just updating to more up-to-date practices. Nevertheless, I'd suggest reviewing the [comparison](https://github.com/geerlingguy/ansible-role-docker/compare/7.0.1...7.3.0).

### Pinned

* stefangweichinger.ansible_rclone 0.2.0
* community.general 9.3.0
* vladgh.samba 3.4.0