### PR TITLE
ci: use ansible/ansible-lint action

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        # TODO: pin to version once >24.7.0 is released
-        # See https://github.com/ansible/ansible-lint/discussions/4281
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@v24.9.0
         with:
           requirements_file: requirements.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24.9.0
+        uses: ansible/ansible-lint@v24.9.2
         with:
           requirements_file: requirements.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,29 +3,17 @@ name: Lint MANS
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
-
     steps:
-
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        # TODO: pin to version once >24.7.0 is released
+        # See https://github.com/ansible/ansible-lint/discussions/4281
+        uses: ansible/ansible-lint@main
         with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ansible-lint yamllint
-
-      - name: Run linters
-        run: |
-          ansible-lint -c .ansible-lint .
+          requirements_file: requirements.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,11 @@ roles:
     version: 7.3.0
 
 collections:
+  - name: ansible.posix
+    version: 1.5.4
   - name: community.general
     version: 9.3.0
+  - name: community.docker
+    version: 3.12.1
   - name: vladgh.samba
     version: 3.4.0


### PR DESCRIPTION
> [!WARNING]  
> This conflicts with #2 since it's also modifying the ansible-lint workflow file.
> **Please merge #2 first**, then I'll rebase this branch so it's ready to go.

In addition to swapping 'manual' commands for the ansible/ansible-lint action, I...
* Added missing ansible collections.
* Added the `workflow_dispatch` trigger to the workflow to allow triggering manually.
