### PR TITLE
refactor: improvements on `become` & `sudo` usage

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,7 +7,6 @@ skip_list:
   - name[casing]
   - name[template]
   - var-naming[no-role-prefix]
-  - partial-become[task]
   - no-changed-when
   - risky-file-permissions
   - command-instead-of-module

--- a/roles/configure_mergerfs/tasks/configure_perms.yml
+++ b/roles/configure_mergerfs/tasks/configure_perms.yml
@@ -5,7 +5,6 @@
     owner: "{{ user }}"
     group: "{{ media_group }}"
     mode: "0770"
-  become: true
 
 - name: Set permissions on media_noncached
   ansible.builtin.file:
@@ -13,7 +12,6 @@
     owner: "{{ user }}"
     group: "{{ media_group }}"
     mode: "0770"
-  become: true
   when: not cache_disks_exist
 
 - name: Set permissions on .snapshots directory for media_cached
@@ -23,7 +21,6 @@
     group: root
     mode: "0770"
     recurse: true
-  become: true
   failed_when: false
   when: cache_disks_exist
 
@@ -34,6 +31,5 @@
     group: root
     mode: "0770"
     recurse: true
-  become: true
   failed_when: false
   when: not cache_disks_exist

--- a/roles/configure_snapraid/tasks/configure_snapraid-btrfs-runner.yml
+++ b/roles/configure_snapraid/tasks/configure_snapraid-btrfs-runner.yml
@@ -52,4 +52,3 @@
     name: snapraid-btrfs-runner.timer
     enabled: true
     state: started
-  become: true

--- a/roles/configure_snapraid/tasks/configure_snapraid.yml
+++ b/roles/configure_snapraid/tasks/configure_snapraid.yml
@@ -7,7 +7,6 @@
     group: root
     mode: "0755"
   loop: "{{ content_files }}"
-  become: true
 
 - name: Generate SnapRAID configuration
   ansible.builtin.template:

--- a/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
+++ b/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
@@ -23,7 +23,6 @@
   register: snapraid_btrfs_output
   changed_when: false
   failed_when: snapraid_btrfs_output.rc != 0 and "No snapper configs found" not in snapraid_btrfs_output.stderr
-  become: true
 
 - name: Display snapraid-btrfs output
   ansible.builtin.debug:

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -23,7 +23,7 @@
 
     - name: Verify existing snapper configs
       ansible.builtin.command:
-        cmd: sudo snapper list-configs
+        cmd: snapper list-configs
       register: snapper_configs
       changed_when: false
       failed_when: false
@@ -40,7 +40,7 @@
 
     - name: Destroy invalid snapper configurations
       ansible.builtin.command:
-        cmd: sudo snapper -c data{{ '%02d' % item }} delete-config
+        cmd: snapper -c data{{ '%02d' % item }} delete-config
       loop: "{{ range(1, data_disks | length + 1) }}"
       when:
         - data_disks is defined
@@ -51,7 +51,7 @@
 
     - name: Attempt to create Snapper configuration
       ansible.builtin.command:
-        cmd: sudo snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
+        cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
       register: create_config_result
       failed_when: false
       changed_when: create_config_result.rc == 0
@@ -63,7 +63,7 @@
 
     - name: Remove existing snapshots for failed configs  # noqa command-instead-of-module
       ansible.builtin.command:
-        cmd: sudo btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots/*
+        cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots/*
       loop: "{{ range(1, data_disks | length + 1) }}"
       when:
         - data_disks is defined
@@ -74,7 +74,7 @@
 
     - name: Remove .snapshots subvolume for failed configs  # noqa command-instead-of-module
       ansible.builtin.command:
-        cmd: sudo btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots
+        cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots
       loop: "{{ range(1, data_disks | length + 1) }}"
       when:
         - data_disks is defined
@@ -85,7 +85,7 @@
 
     - name: Retry creating Snapper configuration for failed configs
       ansible.builtin.command:
-        cmd: sudo snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
+        cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
       loop: "{{ range(1, data_disks | length + 1) }}"
       when:
         - data_disks is defined
@@ -105,7 +105,7 @@
 
     - name: Verify snapper configs
       ansible.builtin.command:
-        cmd: sudo snapper list-configs
+        cmd: snapper list-configs
       register: snapper_configs_new
       changed_when: false
 
@@ -158,20 +158,20 @@
 
         - name: Delete all snapshots  # noqa command-instead-of-module
           ansible.builtin.command:
-            cmd: "sudo btrfs subvolume delete -C {{ item.1.path }}/snapshot"
+            cmd: "btrfs subvolume delete -C {{ item.1.path }}/snapshot"
           loop: "{{ snapshot_dirs.results | subelements('files') }}"
           when: snapshot_dirs.results is defined
           failed_when: false
 
         - name: Remove .snapshots subvolume on all disks  # noqa command-instead-of-module
           ansible.builtin.command:
-            cmd: "sudo btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots"
+            cmd: "btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots"
           loop: "{{ range(1, data_disks | length + 1) | list }}"
           failed_when: false
 
         - name: Recreate all snapper configs
           ansible.builtin.command:
-            cmd: "sudo snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}"
+            cmd: "snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}"
           loop: "{{ range(1, data_disks | length + 1) | list }}"
           register: create_config_result
           failed_when:
@@ -190,7 +190,7 @@
 
         - name: Verify final snapper configs after reset
           ansible.builtin.command:
-            cmd: sudo snapper list-configs
+            cmd: snapper list-configs
           register: snapper_configs_reset
           changed_when: false
 
@@ -225,7 +225,7 @@
   always:
     - name: Final verification of Snapper configs
       ansible.builtin.command:
-        cmd: sudo snapper list-configs
+        cmd: snapper list-configs
       register: final_snapper_configs
       changed_when: false
 

--- a/roles/install_btrfs/tasks/install.yml
+++ b/roles/install_btrfs/tasks/install.yml
@@ -51,7 +51,7 @@
 
 - name: Install btrfs-progs # noqa command-instead-of-shell
   ansible.builtin.shell:
-    cmd: sudo make install
+    cmd: make install
     chdir: /tmp/btrfs-progs
 
 - name: Cleanup cloned repository

--- a/roles/manage_zsh/tasks/main.yml
+++ b/roles/manage_zsh/tasks/main.yml
@@ -5,13 +5,11 @@
       - zsh
       - powerline
     state: present
-  become: true
 
 - name: Set ZSH as default shell
   ansible.builtin.user:
     name: "{{ user }}"
     shell: /bin/zsh
-  become: true
 
 - name: Install Oh My ZSH
   block:
@@ -27,110 +25,107 @@
         path: /home/{{ user }}/.oh-my-zsh
       register: zsh_ohmyzsh_installed
 
-    - name: Run Oh My ZSH installer
+    - name: Become user for ZSH config
+      become: true
       become_user: "{{ user }}"
-      ansible.builtin.command: /tmp/install-ohmyzsh.sh --unattended
-      when: not zsh_ohmyzsh_installed.stat.exists
+      block:
+        - name: Run Oh My ZSH installer
+          ansible.builtin.command: /tmp/install-ohmyzsh.sh --unattended
+          when: not zsh_ohmyzsh_installed.stat.exists
 
-- name: Install Oh My ZSH plugins
-  become_user: "{{ user }}"
-  ansible.builtin.git:
-    repo: "{{ item.repo }}"
-    dest: "/home/{{ user }}/.oh-my-zsh/custom/plugins/{{ item.name }}"
-    version: master
-    force: true
-  loop:
-    - { name: zsh-autosuggestions, repo: https://github.com/zsh-users/zsh-autosuggestions }
-    - { name: zsh-syntax-highlighting, repo: https://github.com/zsh-users/zsh-syntax-highlighting }
+        - name: Install Oh My ZSH plugins
+          ansible.builtin.git:
+            repo: "{{ item.repo }}"
+            dest: "/home/{{ user }}/.oh-my-zsh/custom/plugins/{{ item.name }}"
+            version: master
+            force: true
+          loop:
+            - { name: zsh-autosuggestions, repo: https://github.com/zsh-users/zsh-autosuggestions }
+            - { name: zsh-syntax-highlighting, repo: https://github.com/zsh-users/zsh-syntax-highlighting }
 
-- name: Add fastfetch aliases
-  become_user: "{{ user }}"
-  ansible.builtin.blockinfile:
-    path: "/home/{{ user }}/.zshrc"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - Fastfetch aliases"
-    block: |
-      # Aliases for fastfetch
-      alias fetch='fastfetch'
-      alias neofetch='fastfetch'
-    insertafter: EOF
+        - name: Add fastfetch aliases
+          ansible.builtin.blockinfile:
+            path: "/home/{{ user }}/.zshrc"
+            marker: "# {mark} ANSIBLE MANAGED BLOCK - Fastfetch aliases"
+            block: |
+              # Aliases for fastfetch
+              alias fetch='fastfetch'
+              alias neofetch='fastfetch'
+            insertafter: EOF
 
-- name: Install and configure Powerlevel10k
-  when: configure_powerlevel10k
-  block:
-    - name: Clone Powerlevel10k
-      become_user: "{{ user }}"
-      ansible.builtin.git:
-        repo: https://github.com/romkatv/powerlevel10k
-        dest: /home/{{ user }}/.oh-my-zsh/custom/themes/powerlevel10k
-        version: master
-        force: true
+        - name: Install and configure Powerlevel10k
+          when: configure_powerlevel10k
+          block:
+            - name: Clone Powerlevel10k
+              ansible.builtin.git:
+                repo: https://github.com/romkatv/powerlevel10k
+                dest: /home/{{ user }}/.oh-my-zsh/custom/themes/powerlevel10k
+                version: master
+                force: true
 
-    - name: Set Powerlevel10k as the default theme
-      become_user: "{{ user }}"
-      ansible.builtin.lineinfile:
-        path: /home/{{ user }}/.zshrc
-        regexp: ^ZSH_THEME=".*"
-        line: ZSH_THEME="powerlevel10k/powerlevel10k"
-        state: present
+            - name: Set Powerlevel10k as the default theme
+              ansible.builtin.lineinfile:
+                path: /home/{{ user }}/.zshrc
+                regexp: ^ZSH_THEME=".*"
+                line: ZSH_THEME="powerlevel10k/powerlevel10k"
+                state: present
 
-    # - name: Add Powerlevel10k instant prompt to .zshrc
-    #   become_user: "{{ user }}"
-    #   ansible.builtin.blockinfile:
-    #     path: /home/{{ user }}/.zshrc
-    #     insertbefore: BOF
-    #     block: |
-    #       # Enable Powerlevel10k instant prompt
-    #       if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-    #         source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-    #       fi
+            # - name: Add Powerlevel10k instant prompt to .zshrc
+            #   ansible.builtin.blockinfile:
+            #     path: /home/{{ user }}/.zshrc
+            #     insertbefore: BOF
+            #     block: |
+            #       # Enable Powerlevel10k instant prompt
+            #       if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+            #         source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+            #       fi
 
 - name: Configure fastfetch motd
   when: fastfetch_motd | default(false) | bool
   block:
-    - name: Create fastfetch script
-      become_user: "{{ user }}"
-      ansible.builtin.copy:
-        dest: "/home/{{ user }}/.fastfetch.sh"
-        mode: '0755'
-        content: |
-          #!/bin/bash
-          if [[ $- == *i* && $TERM_PROGRAM != "vscode" && -z "$FASTFETCH_DISPLAYED" ]]; then
-            fastfetch
-            export FASTFETCH_DISPLAYED=1
-          fi
 
-    - name: Source fastfetch script in .zshrc
+    - name: Become user for fastfetch script
+      become: true
       become_user: "{{ user }}"
-      ansible.builtin.blockinfile:
-        path: "/home/{{ user }}/.zshrc"
-        marker: "# {mark} ANSIBLE MANAGED BLOCK - Fastfetch"
-        block: |
-          # Run fastfetch
-          source ~/.fastfetch.sh
-        insertafter: "# {mark} ANSIBLE MANAGED BLOCK - Powerlevel10k instant prompt"
+      block:
+        - name: Create fastfetch script
+          ansible.builtin.copy:
+            dest: "/home/{{ user }}/.fastfetch.sh"
+            mode: '0755'
+            content: |
+              #!/bin/bash
+              if [[ $- == *i* && $TERM_PROGRAM != "vscode" && -z "$FASTFETCH_DISPLAYED" ]]; then
+                fastfetch
+                export FASTFETCH_DISPLAYED=1
+              fi
 
-    - name: Source fastfetch script in .zprofile
-      become_user: "{{ user }}"
-      ansible.builtin.lineinfile:
-        path: "/home/{{ user }}/.zprofile"
-        line: 'source ~/.fastfetch.sh'
-        create: true
+        - name: Source fastfetch script in .zshrc
+          ansible.builtin.blockinfile:
+            path: "/home/{{ user }}/.zshrc"
+            marker: "# {mark} ANSIBLE MANAGED BLOCK - Fastfetch"
+            block: |
+              # Run fastfetch
+              source ~/.fastfetch.sh
+            insertafter: "# {mark} ANSIBLE MANAGED BLOCK - Powerlevel10k instant prompt"
+
+        - name: Source fastfetch script in .zprofile
+          ansible.builtin.lineinfile:
+            path: "/home/{{ user }}/.zprofile"
+            line: 'source ~/.fastfetch.sh'
+            create: true
 
     - name: Disable default MOTD
-      become: true
       ansible.builtin.file:
         path: /etc/motd
         state: absent
 
     - name: Disable login information in /etc/issue
-      become: true
       ansible.builtin.copy:
         content: ""
         dest: /etc/issue
         force: true
 
     - name: Disable login information in /etc/issue.net
-      become: true
       ansible.builtin.copy:
         content: ""
         dest: /etc/issue.net

--- a/roles/muffins_cache_mover/handlers/main.yml
+++ b/roles/muffins_cache_mover/handlers/main.yml
@@ -1,11 +1,9 @@
 ---
 - name: reload systemd
-  become: true
   ansible.builtin.systemd:
     daemon_reload: true
 
 - name: start and enable cache mover timer
-  become: true
   ansible.builtin.systemd:
     name: cache_mover.timer
     state: started


### PR DESCRIPTION
* Remove `sudo` from commands - This is of course unnecessary when using `become`.
* Remove spurious `become` statements at task level - `become` is already `true` by default at play level.  
  It was either this or go through and find every task that requires privilege escalation and add `become: true` where missing to keep things consistent. I chose this approach instead for the sake of simplicity. The alternative of maintaining correct usage of `become` for every task requiring it would be far too error-prone and maintenance heavy.
* As part of the above, mostly in `manage_zsh`: refactor various instances of `become_user` at task-level to use blocks.
* Remove `partial-become[task]` lint rule from `skip_list` and fix failures. Not necessary, just typically easier to maintain adherence to lint rules IMO.