### PR TITLE
configure_snapraid: Fixes & improvements

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,6 +12,7 @@ skip_list:
   - command-instead-of-module
   - role-name
   - yaml[line-length]
+  - ignore-errors
 
 use_default_rules: true
 

--- a/roles/configure_snapraid/tasks/install.yml
+++ b/roles/configure_snapraid/tasks/install.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Ensure openSUSE Snapper repository key
+  ansible.builtin.get_url:
+    url: https://download.opensuse.org/repositories/filesystems:snapper/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}/Release.key
+    dest: /etc/apt/trusted.gpg.d/opensuse_snapper.asc
+    owner: root
+    group: root
+    mode: "0644"
+  register: snapper_apt_key
+
+- name: Add openSUSE Snapper repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [signed-by={{ snapper_apt_key.dest }}]
+      http://download.opensuse.org/repositories/filesystems:/snapper/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}/ /
+    filename: opensuse_snapper
+    state: present
+
+- name: Install Snapper
+  ansible.builtin.apt:
+    name: snapper
+    state: present

--- a/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
+++ b/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
@@ -27,3 +27,13 @@
 - name: Display snapraid-btrfs output
   ansible.builtin.debug:
     var: snapraid_btrfs_output.stdout_lines
+
+# TODO: Remove this once the following PR is merged https://github.com/automorphism88/snapraid-btrfs/pull/34
+- name: Patch snapraid-btrfs
+  ansible.builtin.lineinfile:
+    path: /usr/local/bin/snapraid-btrfs
+    regexp: >-
+      ^(\s{8})sed -e '/\^SUBVOLUME /!d' -e 's/\^SUBVOLUME\[ ]\*\| //'\)\"$
+    line: >-
+      \1sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*[|│] //')"
+    backrefs: true

--- a/roles/configure_snapraid/tasks/main.yml
+++ b/roles/configure_snapraid/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Install snapper
+  ansible.builtin.include_tasks:
+    file: install.yml
+
 - name: SnapRAID base config
   ansible.builtin.include_tasks:
     file: configure_snapraid.yml

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -73,27 +73,21 @@
               snapshots.results | selectattr('matched', '>', 0) | map(attribute='files') | flatten | map(attribute='path')
               if snapshots is not skipped else []
             }}
-          when:
-            - not config_validity.results[item-1].ansible_facts.config_valid
-            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          when: snapshots is not skipped
           ignore_errors: true
 
         - name: Remove .snapshots subvolume for failed configs  # noqa command-instead-of-module
           ansible.builtin.command:
             cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots
           loop: "{{ range(1, data_disks | length + 1) }}"
-          when:
-            - not config_validity.results[item-1].ansible_facts.config_valid
-            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          when: snapshots is not skipped
           ignore_errors: true
 
         - name: Retry creating Snapper configuration for failed configs
           ansible.builtin.command:
             cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
           loop: "{{ range(1, data_disks | length + 1) }}"
-          when:
-            - not config_validity.results[item-1].ansible_facts.config_valid
-            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          when: snapshots is not skipped
           register: create_config_result_retry
           changed_when: create_config_result_retry.rc == 0
           ignore_errors: true

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -53,10 +53,26 @@
           loop: "{{ range(1, data_disks | length + 1) }}"
           when: not config_validity.results[item-1].ansible_facts.config_valid
 
+        - name: Discover snapshots
+          ansible.builtin.find:
+            path: "{{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots"
+            file_type: directory
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          loop_control:
+            label: "data{{ '%02d' % item }}"
+          when:
+            - not config_validity.results[item-1].ansible_facts.config_valid
+            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          register: snapshots
+
         - name: Remove existing snapshots for failed configs  # noqa command-instead-of-module
           ansible.builtin.command:
-            cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots/*
-          loop: "{{ range(1, data_disks | length + 1) }}"
+            cmd: btrfs subvolume delete -C {{ item }}/snapshot
+          loop: >-
+            {{
+              snapshots.results | selectattr('matched', '>', 0) | map(attribute='files') | flatten | map(attribute='path')
+              if snapshots is not skipped else []
+            }}
           when:
             - not config_validity.results[item-1].ansible_facts.config_valid
             - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -1,13 +1,7 @@
 ---
+
 - name: Snapper configuration
   block:
-    - name: Install snapper
-      ansible.builtin.apt:
-        name:
-          - snapper
-        state: present
-        update_cache: false
-
     - name: Ensure the base config is named 'default'
       ansible.builtin.copy:
         src: /usr/share/snapper/config-templates/default

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -141,11 +141,15 @@
   rescue:
     - name: Reset Snapper configurations
       block:
-        - name: Clear SNAPPER_CONFIGS in /etc/default/snapper
+        - name: Clear SNAPPER_CONFIGS
           ansible.builtin.lineinfile:
-            path: /etc/default/snapper
+            path: "{{ item }}"
             regexp: '^SNAPPER_CONFIGS='
             line: 'SNAPPER_CONFIGS=""'
+          loop:
+            - /etc/default/snapper # old default snapper config path
+            - /etc/sysconfig/snapper
+          ignore_errors: true
 
         - name: Remove individual snapper configs
           ansible.builtin.file:

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -114,9 +114,15 @@
       changed_when: false
       ignore_errors: true
 
-    - name: Check for invalid btrfs subvolume
+    - name: Check for invalid btrfs subvolume and snapper config creation failure
       ansible.builtin.set_fact:
         invalid_subvolume: "{{ 'is not a valid btrfs subvolume' in snapraid_btrfs_output.stderr }}"
+        snapper_config_creation_failed: >-
+          {{
+            not ansible_check_mode
+            and ((create_config_result.rc != 0 if create_config_result is not skipped else false)
+            or (create_config_result_retry.rc != 0 if create_config_result_retry is not skipped else false))
+          }}
 
     - name: Display snapraid-btrfs output
       ansible.builtin.debug:
@@ -126,6 +132,11 @@
       ansible.builtin.fail:
         msg: "Invalid btrfs subvolume detected. Initiating reset process."
       when: invalid_subvolume | bool
+
+    - name: Fail if snapper config creation failed
+      ansible.builtin.fail:
+        msg: "Snapper config creation failed. Initiating reset process."
+      when: snapper_config_creation_failed | bool
 
   rescue:
     - name: Reset Snapper configurations

--- a/roles/configure_snapraid/tasks/snapper_config.yml
+++ b/roles/configure_snapraid/tasks/snapper_config.yml
@@ -26,7 +26,7 @@
         cmd: snapper list-configs
       register: snapper_configs
       changed_when: false
-      failed_when: false
+      ignore_errors: true
 
     - name: Display snapper_configs
       ansible.builtin.debug:
@@ -38,61 +38,55 @@
       loop: "{{ range(1, data_disks | length + 1) }}"
       register: config_validity
 
-    - name: Destroy invalid snapper configurations
-      ansible.builtin.command:
-        cmd: snapper -c data{{ '%02d' % item }} delete-config
-      loop: "{{ range(1, data_disks | length + 1) }}"
+    - name: Conditionally rebuild snapper configs if data_disks exist
       when:
         - data_disks is defined
         - data_disks|length > 0
-        - not config_validity.results[item-1].ansible_facts.config_valid
-        - snapper_configs.stdout_lines | length > 2
-      failed_when: false
+      block:
+        - name: Destroy invalid snapper configurations
+          ansible.builtin.command:
+            cmd: snapper -c data{{ '%02d' % item }} delete-config
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          when: not config_validity.results[item-1].ansible_facts.config_valid
+          ignore_errors: true
 
-    - name: Attempt to create Snapper configuration
-      ansible.builtin.command:
-        cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
-      register: create_config_result
-      failed_when: false
-      changed_when: create_config_result.rc == 0
-      loop: "{{ range(1, data_disks | length + 1) }}"
-      when:
-        - data_disks is defined
-        - data_disks|length > 0
-        - not config_validity.results[item-1].ansible_facts.config_valid
+        - name: Attempt to create Snapper configuration
+          ansible.builtin.command:
+            cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
+          register: create_config_result
+          changed_when: create_config_result.rc == 0
+          ignore_errors: true
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          when: not config_validity.results[item-1].ansible_facts.config_valid
 
-    - name: Remove existing snapshots for failed configs  # noqa command-instead-of-module
-      ansible.builtin.command:
-        cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots/*
-      loop: "{{ range(1, data_disks | length + 1) }}"
-      when:
-        - data_disks is defined
-        - data_disks|length > 0
-        - not config_validity.results[item-1].ansible_facts.config_valid
-        - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
-      failed_when: false
+        - name: Remove existing snapshots for failed configs  # noqa command-instead-of-module
+          ansible.builtin.command:
+            cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots/*
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          when:
+            - not config_validity.results[item-1].ansible_facts.config_valid
+            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          ignore_errors: true
 
-    - name: Remove .snapshots subvolume for failed configs  # noqa command-instead-of-module
-      ansible.builtin.command:
-        cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots
-      loop: "{{ range(1, data_disks | length + 1) }}"
-      when:
-        - data_disks is defined
-        - data_disks|length > 0
-        - not config_validity.results[item-1].ansible_facts.config_valid
-        - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
-      failed_when: false
+        - name: Remove .snapshots subvolume for failed configs  # noqa command-instead-of-module
+          ansible.builtin.command:
+            cmd: btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          when:
+            - not config_validity.results[item-1].ansible_facts.config_valid
+            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          ignore_errors: true
 
-    - name: Retry creating Snapper configuration for failed configs
-      ansible.builtin.command:
-        cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
-      loop: "{{ range(1, data_disks | length + 1) }}"
-      when:
-        - data_disks is defined
-        - data_disks|length > 0
-        - not config_validity.results[item-1].ansible_facts.config_valid
-        - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
-      failed_when: false
+        - name: Retry creating Snapper configuration for failed configs
+          ansible.builtin.command:
+            cmd: snapper -c data{{ '%02d' % item }} create-config -t default {{ data_mount_path }}/data{{ '%02d' % item }}
+          loop: "{{ range(1, data_disks | length + 1) }}"
+          when:
+            - not config_validity.results[item-1].ansible_facts.config_valid
+            - "'creating btrfs subvolume .snapshots failed since it already exists' in create_config_result.results[item-1].stderr"
+          register: create_config_result_retry
+          changed_when: create_config_result_retry.rc == 0
+          ignore_errors: true
 
     - name: Ensure 'TIMELINE_CREATE="no"' in each data disk's Snapper configuration
       ansible.builtin.lineinfile:
@@ -101,7 +95,7 @@
         line: TIMELINE_CREATE="no"
       loop: "{{ range(1, data_disks | length + 1) }}"
       when: data_disks is defined and data_disks|length > 0
-      failed_when: false
+      ignore_errors: true
 
     - name: Verify snapper configs
       ansible.builtin.command:
@@ -118,7 +112,7 @@
         cmd: /usr/local/bin/snapraid-btrfs list
       register: snapraid_btrfs_output
       changed_when: false
-      failed_when: false
+      ignore_errors: true
 
     - name: Check for invalid btrfs subvolume
       ansible.builtin.set_fact:
@@ -154,20 +148,20 @@
             file_type: directory
           loop: "{{ range(1, data_disks | length + 1) | list }}"
           register: snapshot_dirs
-          failed_when: false
+          ignore_errors: true
 
         - name: Delete all snapshots  # noqa command-instead-of-module
           ansible.builtin.command:
             cmd: "btrfs subvolume delete -C {{ item.1.path }}/snapshot"
           loop: "{{ snapshot_dirs.results | subelements('files') }}"
           when: snapshot_dirs.results is defined
-          failed_when: false
+          ignore_errors: true
 
         - name: Remove .snapshots subvolume on all disks  # noqa command-instead-of-module
           ansible.builtin.command:
             cmd: "btrfs subvolume delete -C {{ data_mount_path }}/data{{ '%02d' % item }}/.snapshots"
           loop: "{{ range(1, data_disks | length + 1) | list }}"
-          failed_when: false
+          ignore_errors: true
 
         - name: Recreate all snapper configs
           ansible.builtin.command:
@@ -186,7 +180,7 @@
             regexp: ^TIMELINE_CREATE=
             line: TIMELINE_CREATE="no"
           loop: "{{ range(1, data_disks | length + 1) | list }}"
-          failed_when: false
+          ignore_errors: true
 
         - name: Verify final snapper configs after reset
           ansible.builtin.command:
@@ -238,7 +232,7 @@
         cmd: /usr/local/bin/snapraid-btrfs list
       register: final_snapraid_btrfs_output
       changed_when: false
-      failed_when: false
+      ignore_errors: true
 
     - name: Display final snapraid-btrfs output
       ansible.builtin.debug:


### PR DESCRIPTION
* Nest tasks with shared conditions into a block where possible (note some conditions cannot be shared as they rely on the loop variable within each task).

* Replace `failed_when: false` with `ignore_errors: true`. This goes against lint rules, and users who aren't familiar with Ansible or the operations being carried out here may be worried by the resulting output. However, IMO, this is outweighed by the importance of being able to see when something has *potentially* gone wrong rather than simply allowing silent failures.

* Add test to ensure Snapper config creation failures are caught.

* Ensure `SNAPPER_CONFIGS` is cleared in all config paths when retrying setup - `/etc/default/snapper` was previously the default, but in newer versions of snapper it seems to have moved to `/etc/sysconfig/snapper`. Sometimes it still looks at both config files, so it's critical to make this change in both places if they both exist.

* patch [snapraid-btrfs](https://github.com/automorphism88/snapraid-btrfs) to work with new versions of snapper

* Install Snapper from openSUSE apt repo

* Fix snapshot cleanup when snapper config creation fails. The current method of attempting `btrfs subvolume delete -C <disk>/.snapshots/*` isn't allowed. Instead, discover snapshots on all `data_disks` with `find` module, then iterate over each one to run `btrfs subvolume delete <path>`.