### PR TITLE
manage_disks_nas: fix wipe/setup condition, style/refactor changes

### DIFF
--- a/roles/manage_disks_nas/tasks/configure_mount_perms.yml
+++ b/roles/manage_disks_nas/tasks/configure_mount_perms.yml
@@ -11,7 +11,7 @@
     - "{{ cache_mount_path }}"
     - "{{ parity_mount_path }}"
 
-- name: Check if .snapshots directories exist
+- name: Discover .snapshots directories
   ansible.builtin.stat:
     path: "{{ data_mount_path }}/data{{ '%02d' | format(item) }}/.snapshots"
   loop: "{{ range(1, data_disks_count | int + 1) | list }}"
@@ -19,7 +19,7 @@
     loop_var: item
   register: snapshot_directory_check
 
-- name: Set ownership and permissions on .snapshots directories that exist
+- name: Set ownership and permissions on existing .snapshots directories
   ansible.builtin.file:
     path: "{{ item.stat.path }}"
     state: directory

--- a/roles/manage_disks_nas/tasks/configure_parity_cache.yml
+++ b/roles/manage_disks_nas/tasks/configure_parity_cache.yml
@@ -33,54 +33,53 @@
     index_var: index
 
 # Cache Disks
-- name: Ensure cache disk mounts are present in fstab
-  ansible.builtin.blockinfile:
-    path: /etc/fstab
-    block: |
-      {% for disk in cache_disks_only %}
-      {% if disk in partitioned_disks %}
-      {{ disk }}-part1  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
-      {% else %}
-      {{ disk }}  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
-      {% endif %}
-      {% endfor %}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - CACHE DISK MOUNTS"
+- name: Cache disks block
   when: cache_disks_only | length > 0
+  block:
+    - name: Ensure cache disk mounts are present in fstab
+      ansible.builtin.blockinfile:
+        path: /etc/fstab
+        block: |
+          {% for disk in cache_disks_only %}
+          {% if disk in partitioned_disks %}
+          {{ disk }}-part1  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
+          {% else %}
+          {{ disk }}  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
+          {% endif %}
+          {% endfor %}
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - CACHE DISK MOUNTS"
 
-- name: Ensure cache disk mounts are present in fstab
-  ansible.builtin.blockinfile:
-    path: /etc/fstab
-    block: |
-      {% for disk in cache_disks_only %}
-      {{ disk }}  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
-      {% endfor %}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - CACHE DISK MOUNTS"
-  when: cache_disks_only | length > 0
+    - name: Ensure cache disk mounts are present in fstab
+      ansible.builtin.blockinfile:
+        path: /etc/fstab
+        block: |
+          {% for disk in cache_disks_only %}
+          {{ disk }}  {{ cache_mount_path }}/cache{{ '%02d' % (loop.index) }}  ext4  {{ manage_disks_nas_ext4_mount_opts }}  0  0
+          {% endfor %}
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - CACHE DISK MOUNTS"
 
-- name: Mount cache disks
-  ansible.posix.mount:
-    path: "{{ cache_mount_path }}/cache{{ '%02d' % (index + 1) }}"
-    src: "{{ item if item not in partitioned_disks else item + '-part1' }}"
-    fstype: ext4
-    opts: "{{ manage_disks_nas_ext4_mount_opts }}"
-    state: mounted
-  loop: "{{ cache_disks_only }}"
-  loop_control:
-    index_var: index
-  when: cache_disks_only | length > 0
+    - name: Mount cache disks
+      ansible.posix.mount:
+        path: "{{ cache_mount_path }}/cache{{ '%02d' % (index + 1) }}"
+        src: "{{ item if item not in partitioned_disks else item + '-part1' }}"
+        fstype: ext4
+        opts: "{{ manage_disks_nas_ext4_mount_opts }}"
+        state: mounted
+      loop: "{{ cache_disks_only }}"
+      loop_control:
+        index_var: index
 
-- name: Set permissions on cache disk directories
-  ansible.builtin.file:
-    path: "{{ cache_mount_path }}/cache{{ '%02d' % (index + 1) }}"
-    state: directory
-    owner: "{{ user }}"
-    group: "{{ media_group }}"
-    mode: "0770"
-    recurse: true
-  loop: "{{ cache_disks_only }}"
-  loop_control:
-    index_var: index
-  when: cache_disks_only | length > 0
+    - name: Set permissions on cache disk directories
+      ansible.builtin.file:
+        path: "{{ cache_mount_path }}/cache{{ '%02d' % (index + 1) }}"
+        state: directory
+        owner: "{{ user }}"
+        group: "{{ media_group }}"
+        mode: "0770"
+        recurse: true
+      loop: "{{ cache_disks_only }}"
+      loop_control:
+        index_var: index
 
 # Cache Paths
 - name: Ensure cache paths exist

--- a/roles/manage_disks_nas/tasks/main.yml
+++ b/roles/manage_disks_nas/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
-- name: Prepare Disks
+- name: Prepare disks
   ansible.builtin.include_tasks:
     file: prepare_disks.yml
 
-- name: Configure btrfs Subvolumes
+- name: Configure Btrfs subvolumes
   ansible.builtin.include_tasks:
     file: configure_subvolumes.yml
 
-- name: Configure btrfs Subvolume Mount
+- name: Configure Btrfs subvolume mounts
   ansible.builtin.include_tasks:
     file: configure_subvolume_mount.yml
 
@@ -15,6 +15,6 @@
   ansible.builtin.include_tasks:
     file: configure_parity_cache.yml
 
-- name: Set perms on mounts
+- name: Set mount permissions
   ansible.builtin.include_tasks:
     file: configure_mount_perms.yml

--- a/roles/manage_disks_nas/tasks/prepare_disks.yml
+++ b/roles/manage_disks_nas/tasks/prepare_disks.yml
@@ -96,7 +96,12 @@
 
 - name: Debug prompt condition
   ansible.builtin.debug:
-    msg: "Prompt condition: {{ ((disks_to_wipe | default([]) | length > 0) or (non_btrfs_disks | default([]) | length > 0) or (non_ext4_disks | default([]) | length > 0)) and (wipe_and_setup | default(false)) }}"
+    msg: >-
+      Prompt condition:
+      {{
+        ((disks_to_wipe | default([]) | length > 0) or (non_btrfs_disks | default([]) | length > 0) or (non_ext4_disks | default([]) | length > 0))
+        and (wipe_and_setup | default(false))
+      }}
 
 - name: Prompt user for confirmation to wipe and reformat disks
   ansible.builtin.pause:

--- a/roles/manage_disks_nas/tasks/prepare_disks.yml
+++ b/roles/manage_disks_nas/tasks/prepare_disks.yml
@@ -145,9 +145,11 @@
     - user_confirmation is defined              # Only run if the prompt was actually shown
     - user_confirmation.user_input | default('n') | lower != 'y'  # Fail if user didn't confirm
 
-- name: Unmount disks_to_wipe # noqa ignore-errors
-  ansible.builtin.command: sudo umount {{ item }}
-  with_items: "{{ disks_to_wipe | default([]) }}"
+- name: Unmount disks_to_wipe
+  ansible.posix.mount:
+    src: "{{ item }}"
+    state: unmounted
+  loop: "{{ disks_to_wipe | default([]) }}"
   when:
     - disks_to_wipe | default([]) | length > 0
     - wipe_and_setup | default(false)

--- a/roles/manage_disks_nas/tasks/prepare_disks.yml
+++ b/roles/manage_disks_nas/tasks/prepare_disks.yml
@@ -141,7 +141,7 @@
       Playbook execution stopped.
   when:
     - disks_to_wipe | default([]) | length > 0  # Only run if there are disks to wipe
-    # - wipe_and_setup | default(false)           # Only run if wipe_and_setup is true
+    - wipe_and_setup | default(false)           # Only run if wipe_and_setup is true
     - user_confirmation is defined              # Only run if the prompt was actually shown
     - user_confirmation.user_input | default('n') | lower != 'y'  # Fail if user didn't confirm
 

--- a/roles/manage_disks_nas/tasks/prepare_disks.yml
+++ b/roles/manage_disks_nas/tasks/prepare_disks.yml
@@ -158,7 +158,7 @@
   ignore_errors: true
 
 - name: Wipe disk labels
-  ansible.builtin.command: sudo wipefs -a {{ item }}
+  ansible.builtin.command: wipefs -a {{ item }}
   with_items: "{{ disks_to_wipe | default([]) }}"
   when:
     - disks_to_wipe | default([]) | length > 0


### PR DESCRIPTION
This PR is mostly stylistic changes and minor refactors which don't affect functionality or results.

The most notable change is the enablement of the `wipe_and_setup` condition in `roles/manage_disks_nas/tasks/prepare_disks.yml`.