### PR TITLE
fix deps & rename default inventory group

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It should look something like this:
 
 ```yml
 ---
-mans-host:
+mans_host:
   hosts:
     hht-fs01:
       ansible_host: hht-fs01.internal.muffn.io

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ To get notifications about your disk health, enable one or more of the notificat
 To install the requirements, in the proect dir run the following:
 
 ```bash
+pip install -r requirements.txt
 ansible-galaxy install -r requirements.yml
 ansible-galaxy collection install -r requirements.yml
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ To install the requirements, in the proect dir run the following:
 ```bash
 pip install -r requirements.txt
 ansible-galaxy install -r requirements.yml
-ansible-galaxy collection install -r requirements.yml
 ```
 
 ## Deploying

--- a/inventories/inventory.example.yml
+++ b/inventories/inventory.example.yml
@@ -1,5 +1,5 @@
 ---
-mans-host:
+mans_host:
   hosts:
     <nas hostname>:
       ansible_host: <some_ip>

--- a/mansplaybook_example.yml
+++ b/mansplaybook_example.yml
@@ -10,7 +10,7 @@
         name: version_check
 
 - name: Maintain MANS
-  hosts: mans-host
+  hosts: mans_host
   become: true
   gather_facts: true
   vars_files:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,0 @@
----
-dependencies:
-  - name: python3
-  - name: pip
-    vars:
-      pip_packages:
-        - name: github3.py
-          version: ">=1.0.0a3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible-core>=2.17.3
+github3.py>=1.0.0a3


### PR DESCRIPTION
* Use valid default group name - Inventory group names but follow the same rules as variable names: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#valid-variable-names
* Remove invalid meta config - Meta deps are a bit of a weird concept but TL;DR they unfortunately don't work like this. See: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#using-role-dependencies
* Add py requirements, update docs