### PR TITLE
fix: no recurse when setting cache disk dir perms

### DIFF
--- a/roles/manage_disks_nas/tasks/configure_parity_cache.yml
+++ b/roles/manage_disks_nas/tasks/configure_parity_cache.yml
@@ -71,7 +71,6 @@
         owner: "{{ user }}"
         group: "{{ media_group }}"
         mode: "0770"
-        recurse: true
       loop: "{{ cache_disks_only }}"
       loop_control:
         index_var: index


### PR DESCRIPTION
Recursively setting permissions on `{{ cache_mount_path }}/cacheXX` would change the permissions of existing subdirs/files.
This is fine on a first run, but once deployed and in use, we don't want to do that.

It's possible I'm off the mark on this one and this is desired for reasons unknown to me. Feel free to close if so.