### PR TITLE
Add more user & group options

### DIFF
--- a/roles/manage_linux/tasks/user_groups.yml
+++ b/roles/manage_linux/tasks/user_groups.yml
@@ -12,4 +12,6 @@
     append: "{{ item.append | default(true) }}"
     create_home: "{{ item.create_home | default(false) }}"
     shell: "{{ item.shell | default(omit) }}"
+    uid: "{{ item.uid | default(omit) }}"
+    state: present
   loop: "{{ users }}"

--- a/roles/manage_linux/tasks/user_groups.yml
+++ b/roles/manage_linux/tasks/user_groups.yml
@@ -11,5 +11,5 @@
     groups: "{{ item.groups }}"
     append: "{{ item.append | default(true) }}"
     create_home: "{{ item.create_home | default(false) }}"
-    shell: "{{ item.shell | default('/bin/bash') }}"
+    shell: "{{ item.shell | default(omit) }}"
   loop: "{{ users }}"

--- a/roles/manage_linux/tasks/user_groups.yml
+++ b/roles/manage_linux/tasks/user_groups.yml
@@ -1,9 +1,22 @@
 ---
+
+- name: Parse groups
+  ansible.builtin.set_fact:
+    create_groups: >-
+      {%- set from_users = users | map(attribute='groups') | flatten | unique
+                          | map('community.general.dict_kv', 'name') | list -%}
+      {%- set explicit = user_groups | default([]) -%}
+      {%- set explicit_names = explicit | map(attribute='name') | list -%}
+      {{ explicit + (from_users | rejectattr('name', 'in', explicit_names) | list) }}
+
 - name: Create groups
   ansible.builtin.group:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
+    gid: "{{ item.gid | default(omit) }}"
     state: present
-  loop: "{{ users | map(attribute='groups') | flatten | unique }}"
+  loop: "{{ create_groups }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Create users
   ansible.builtin.user:

--- a/vars_example.yml
+++ b/vars_example.yml
@@ -49,6 +49,15 @@ users:
       - media
     create_home: false
     shell: /sbin/nologin
+  # The example below demonstrates all available options for users:
+  # - name: some_user    # Required
+  #   groups:            # Required
+  #     - media
+  #     - docker
+  #   append: true       # Optional - Set to false to not append groups and only use the specified groups
+  #   create_home: false # Optional - Defaults to false
+  #   shell: /bin/bash   # Optional - Defaults to system default shell if not specified
+  #   uid: 1001          # Optional - Specify if you want to set a specific UID for the user
 
 # samba config
 samba_users:

--- a/vars_example.yml
+++ b/vars_example.yml
@@ -39,6 +39,10 @@ media_group: media # Group for share perms.
 docker_users:
   - "{{ user }}"
 
+# user_groups: # Optional - Define groups independently of users, use this to set specific GIDs
+#   - name: media
+#     gid: 1234
+
 users:
   - name: "{{ user }}"
     groups:


### PR DESCRIPTION
### Features

The motivation for these changes is that I re-deployed MANS on a freshly installed OS and found that users and groups were created with different UIDs and GIDs than before. This can happen easily and is something I should've anticipated, but nevertheless it resulted in a lot of time spent repairing ownerships. These changes can help avoid this scenario.

- Allow specifying UID for users:
  ```yml
  users:
    - name: foo
      groups: [bar]
      uid: 1234 # Optional
  ```
- Allow specifying GID for groups
  - This adds the new host variable `user_groups`, allowing the user to create groups with a specific GID and/or independently of users (i.e. there is no longer a requirement to define a user as a member of a group for it to be created):
	  ```yml
	  user_groups: # Optional - Define groups independently of users, use this to set specific GIDs
	    - name: media
	      gid: 1234
	
	  users:
	    - name: foo
	      groups:
	        - bar # `bar` will be created with next-free GID
	        - media # `media` will be created with GID 1234 per `user_groups` above
	  ```
  - Groups are collected from `users[].groups` (the schema and usage of this attribute remain unchanged) and the new `user_groups` variable, combined, and then created.
	  - Groups from `user_groups` may have a pre-defined GID
	  - Groups from `users[].groups` will use the next free GID, as before.

### Bug fixes

- Omit user shell if unspecified
  - Avoids overwriting user's preferences if set elsewhere and not explicitly defined in MANS config (ran into this personally)
  - System default will be used if unspecified (omitted).
