### PR TITLE
Improve check mode and reduce noise of expected failures

### DIFF
--- a/roles/configure_mergerfs/tasks/configure_perms.yml
+++ b/roles/configure_mergerfs/tasks/configure_perms.yml
@@ -5,6 +5,7 @@
     owner: "{{ user }}"
     group: "{{ media_group }}"
     mode: "0770"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set permissions on media_noncached
   ansible.builtin.file:
@@ -13,6 +14,7 @@
     group: "{{ media_group }}"
     mode: "0770"
   when: not cache_disks_exist
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set permissions on .snapshots directory for media_cached
   ansible.builtin.file:
@@ -23,6 +25,7 @@
     recurse: true
   failed_when: false
   when: cache_disks_exist
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set permissions on .snapshots directory for media_noncached
   ansible.builtin.file:
@@ -33,3 +36,4 @@
     recurse: true
   failed_when: false
   when: not cache_disks_exist
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/configure_mergerfs/tasks/media_cold.yml
+++ b/roles/configure_mergerfs/tasks/media_cold.yml
@@ -21,3 +21,4 @@
     name: mergerfs-media-cold.service
     enabled: true
     state: started
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/configure_mergerfs/tasks/media_noncached.yml
+++ b/roles/configure_mergerfs/tasks/media_noncached.yml
@@ -21,3 +21,4 @@
     name: mergerfs-media-noncached.service
     enabled: true
     state: started
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/configure_mergerfs/tasks/mergerfs_cleanup.yml
+++ b/roles/configure_mergerfs/tasks/mergerfs_cleanup.yml
@@ -42,6 +42,7 @@
     - mergerfs-cache-disks.service
     - mergerfs-media-cache.service
   when: (cache_disks_only + cache_paths_only) | length > 1
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure mergerfs-media-cache systemd service is enabled and started (single cache disk or path)
   ansible.builtin.systemd:
@@ -49,6 +50,7 @@
     enabled: true
     state: restarted
   when: (cache_disks_only + cache_paths_only) | length == 1
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure mergerfs-media-cold systemd service is enabled and started (cache disks or paths exist)
   ansible.builtin.systemd:
@@ -56,6 +58,7 @@
     enabled: true
     state: restarted
   when: cache_disks_exist is defined and cache_disks_exist
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure mergerfs-media-noncached systemd service is enabled and started (no cache disks or paths)
   ansible.builtin.systemd:
@@ -63,3 +66,4 @@
     enabled: true
     state: restarted
   when: cache_disks_exist is defined and not cache_disks_exist
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/configure_snapraid/tasks/install_snapper.yml
+++ b/roles/configure_snapraid/tasks/install_snapper.yml
@@ -26,6 +26,7 @@
   register: existing_snapper_check
   changed_when: false
   failed_when: false
+  check_mode: false
 
 - name: Check if snapper repository exists
   ansible.builtin.stat:

--- a/roles/install_btrfs/tasks/main.yml
+++ b/roles/install_btrfs/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.command: btrfs --version
   register: installed_version
   changed_when: false
-  ignore_errors: true
+  failed_when: false
   check_mode: false
 
 - name: Set update_needed to true if btrfs is not installed

--- a/roles/install_mergerfs/tasks/main.yml
+++ b/roles/install_mergerfs/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.command: mergerfs --version
   register: installed_mergerfs_version
   changed_when: false
-  ignore_errors: true
+  failed_when: false
   check_mode: false
 
 - name: Set update_needed to true if mergerfs is not installed


### PR DESCRIPTION
- Ignore some errors in `configure_mergerfs` in check mode
	- It's basically impossible to fully support check mode in this project, as I'm sure you're aware, but these are some easy wins for improving the experience.
- Reduce noise of expected failures (`btrfs` and `mergerfs` version checks when not installed)
	- Now just goes green always rather than **big red error** followed by a little _...ignoring_
	- Conditions based on task result remain functional as `rc` attribute is unchanged
- Allow `snapper --version` to be run in check mode
