### PR TITLE
feat(configure_mergerfs): add configurable pool_policy variable

### DIFF
--- a/roles/configure_mergerfs/templates/mergerfs.mount.media_cold.j2
+++ b/roles/configure_mergerfs/templates/mergerfs.mount.media_cold.j2
@@ -9,7 +9,7 @@ ExecStart=/usr/bin/mergerfs \
   -f \
   -o cache.files=partial \
   -o dropcacheonclose=true \
-  -o category.create=epmfs \
+  -o category.create={{ pool_policy }} \
   -o allow_other \
   -o minfreespace={{ configure_mergerfs_minfreespace }} \
   -o fsname=mergerfs_btrfs_cold \

--- a/roles/configure_mergerfs/templates/mergerfs.mount.media_noncached.j2
+++ b/roles/configure_mergerfs/templates/mergerfs.mount.media_noncached.j2
@@ -9,7 +9,7 @@ ExecStart=/usr/bin/mergerfs \
   -f \
   -o cache.files=partial \
   -o dropcacheonclose=true \
-  -o category.create=epmfs \
+  -o category.create={{ pool_policy }} \
   -o allow_other \
   -o minfreespace={{ configure_mergerfs_minfreespace }} \
   -o fsname=mergerfs_btrfs \

--- a/roles/configure_mergerfs/vars/main.yml
+++ b/roles/configure_mergerfs/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 configure_mergerfs_minfreespace: 100G
 configure_mergerfs_cache_minfreespace: 50G
+pool_policy: epmfs

--- a/vars_example.yml
+++ b/vars_example.yml
@@ -120,6 +120,7 @@ cache_mount_path: /mnt/cache-disks
 cache_pool: /mnt/cache-pool # Only used with 2+ cache disks
 
 cache_pool_policy: epmfs # The policy for the cache pool. Leave if using 2+ cache disks and unsure.
+pool_policy: epmfs # The default MergerFS create policy for the main pool. (default: epmfs)
 
 # MergerFS minfreespace settings
 # configure_mergerfs_cache_minfreespace: 50G # Minimum free space for cache disks (default: 50G)


### PR DESCRIPTION
Replaces the hardcoded `epmfs` create policy in the main MergerFS pool mounts (media_cold, media_noncached) with a `pool_policy` variable.

For context, MergerFS changed its default policy to `pfrd` in version 2.41.0 [1]. This new variable allows users to use the new recommended policy, if desired.

Defaults to `epmfs` for backwards compatibility.

[1] https://trapexit.github.io/mergerfs/latest/faq/configuration_and_policies/#why-is-pfrd-the-default-create-policy