### PR TITLE
feat(manage_linux): add manage_linux_apt_maintenance variable

### DIFF
--- a/roles/manage_linux/defaults/main.yml
+++ b/roles/manage_linux/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 timezone: ''
 users: []
+manage_linux_apt_maintenance: true
 
 fastfetch_version: latest
 # wy tf am I supporting risc? lmao

--- a/roles/manage_linux/tasks/main.yml
+++ b/roles/manage_linux/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Apt maintenance
   ansible.builtin.include_tasks:
     file: apt_maintain.yml
+  when: manage_linux_apt_maintenance
 
 - name: Install packages
   ansible.builtin.include_tasks:

--- a/vars_example.yml
+++ b/vars_example.yml
@@ -9,6 +9,7 @@ fastfetch_motd: true
 configure_scrutiny: true # https://github.com/AnalogJ/scrutiny
 configure_hdidle: false  # No longer recommended - See README https://github.com/adelolmo/hd-idle
 skip_os_check: false
+# manage_linux_apt_maintenance: true # Set to false to skip APT upgrade and maintenance entirely. (default: true)
 
 wipe_and_setup: true # Set this to true to enable wiping of disks. If any disks need to be wiped you will be prompted again.
 


### PR DESCRIPTION
Adds a boolean variable to allow skipping the entire APT maintenance task (GPG check, dist-upgrade, autoremove/autoclean) by setting `manage_linux_apt_maintenance: false`.

This is useful to avoid full-system upgrades on every run of the role.

Defaults to `true` for backwards compatibility.