### PR TITLE
fix(manage_disks_nas): skip cache mount root creation when no cache disks

### DIFF
--- a/roles/manage_disks_nas/tasks/configure_mount_perms.yml
+++ b/roles/manage_disks_nas/tasks/configure_mount_perms.yml
@@ -8,8 +8,16 @@
     mode: "770"
   loop:
     - "{{ data_mount_path }}"
-    - "{{ cache_mount_path }}"
     - "{{ parity_mount_path }}"
+
+- name: Set permissions on cache mount root directory
+  ansible.builtin.file:
+    path: "{{ cache_mount_path }}"
+    state: directory
+    owner: "{{ user }}"
+    group: "{{ media_group }}"
+    mode: "770"
+  when: cache_disks_only | length > 0
 
 - name: Discover .snapshots directories
   ansible.builtin.stat:


### PR DESCRIPTION
`configure_mount_perms.yml` unconditionally created the cache mount root directory even when `cache_disks` was empty. Split the task so that `cache_mount_path` is only created when `cache_disks_only` is non-empty.