### PR TITLE
fix(install_snapraid): use regex_search for version extraction

### DIFF
--- a/roles/install_snapraid/tasks/main.yml
+++ b/roles/install_snapraid/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Extract version number from installed snapraid version
   ansible.builtin.set_fact:
-    installed_snapraid_version_number: "{{ installed_snapraid_version.stdout.split()[1] | regex_replace('^v', '') }}"
+    installed_snapraid_version_number: "{{ installed_snapraid_version.stdout | regex_search('v?(\\d[\\d.]*)', '\\1') | first }}"
   when: installed_snapraid_version.rc == 0
 
 - name: Compare installed snapraid version with the latest version


### PR DESCRIPTION
SnapRAID v14 changed its `--version` output:
- Before: `SnapRAID v13.0 by Andrea Mazzoleni, https://www.snapraid.it`
- After: `SnapRAID CLI v14.1 by Andrea Mazzoleni, https://www.snapraid.it`

This breaks the current approach of using `split()[1]` to extract the version number.

Replace with `regex_search` using `v?(\d[\d.]*)` to locate the version token regardless of position, while remaining compatible with older output formats and version strings without a "v" prefix.