### PR TITLE
fix(configure_snapraid): patch snapraid-btrfs before install and improve idempotency

### DIFF
--- a/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
+++ b/roles/configure_snapraid/tasks/install_snapraid-btrfs.yml
@@ -4,6 +4,20 @@
     repo: https://github.com/automorphism88/snapraid-btrfs.git
     dest: /tmp/snapraid-btrfs
     update: true
+    force: true
+  register: snapraid_btrfs_git
+  changed_when: snapraid_btrfs_git.before != snapraid_btrfs_git.after
+
+# TODO: Remove this once the following PR is merged https://github.com/automorphism88/snapraid-btrfs/pull/34
+- name: Patch snapraid-btrfs
+  ansible.builtin.lineinfile:
+    path: /tmp/snapraid-btrfs/snapraid-btrfs
+    regexp: >-
+      ^(\s{8})sed -e '/\^SUBVOLUME /!d' -e 's/\^SUBVOLUME\[ ]\*\| //'\)\"$
+    line: >-
+      \1sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*[|│] //')"
+    backrefs: true
+  changed_when: false
 
 - name: Copy snapraid-btrfs script to /usr/local/bin
   ansible.builtin.copy:
@@ -11,18 +25,3 @@
     dest: /usr/local/bin/snapraid-btrfs
     mode: "0755"
     remote_src: true
-
-- name: Ensure snapraid-btrfs is executable
-  ansible.builtin.file:
-    path: /usr/local/bin/snapraid-btrfs
-    mode: "0755"
-
-# TODO: Remove this once the following PR is merged https://github.com/automorphism88/snapraid-btrfs/pull/34
-- name: Patch snapraid-btrfs
-  ansible.builtin.lineinfile:
-    path: /usr/local/bin/snapraid-btrfs
-    regexp: >-
-      ^(\s{8})sed -e '/\^SUBVOLUME /!d' -e 's/\^SUBVOLUME\[ ]\*\| //'\)\"$
-    line: >-
-      \1sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*[|│] //')"
-    backrefs: true


### PR DESCRIPTION
Apply the `snapraid-btrfs` upstream patch (workaround for the mentioned unmerged PR) directly to the cloned source before copying, rather than patching the installed binary afterwards. This avoids always marking the Ansible task as changed due to the patch, and ensures the copy step only distributes the already-patched version, improving idempotency.

Also, add `force: true` to the git clone step so local modifications don't block updates, and track actual repo changes via before/after commit hashes to avoid false change reports.

Lastly, remove the redundant `chmod` task since the copy step already sets the correct mode.