### PR TITLE
feat: add optional primary-group option for managed users

### DIFF
--- a/roles/manage_linux/tasks/user_groups.yml
+++ b/roles/manage_linux/tasks/user_groups.yml
@@ -21,6 +21,7 @@
 - name: Create users
   ansible.builtin.user:
     name: "{{ item.name }}"
+    group: "{{ item.group | default(omit) }}" 
     groups: "{{ item.groups }}"
     append: "{{ item.append | default(true) }}"
     create_home: "{{ item.create_home | default(false) }}"

--- a/roles/manage_linux/tasks/user_groups.yml
+++ b/roles/manage_linux/tasks/user_groups.yml
@@ -21,7 +21,7 @@
 - name: Create users
   ansible.builtin.user:
     name: "{{ item.name }}"
-    group: "{{ item.group | default(omit) }}" 
+    group: "{{ item.group | default(omit) }}"
     groups: "{{ item.groups }}"
     append: "{{ item.append | default(true) }}"
     create_home: "{{ item.create_home | default(false) }}"

--- a/vars_example.yml
+++ b/vars_example.yml
@@ -46,7 +46,9 @@ media_group: media # Group for share perms.
 docker_users:
   - "{{ user }}"
 
-# user_groups: # Optional - Define groups independently of users, use this to set specific GIDs
+# Optional - Define groups independently of users
+# Use this to create groups without attaching to users or to set specific GIDs
+# user_groups:
 #   - name: media
 #     gid: 1234
 
@@ -62,7 +64,8 @@ users:
     shell: /sbin/nologin
   # The example below demonstrates all available options for users:
   # - name: some_user    # Required
-  #   groups:            # Required
+  #   group: some_user   # Optional - Primary group for the user. If not specified, it will default to the same name as the user (as shown).
+  #   groups:            # Required - Can be an empty list if no additional groups are needed.
   #     - media
   #     - docker
   #   append: true       # Optional - Set to false to not append groups and only use the specified groups


### PR DESCRIPTION
Optional feature; existing deployments/configs are unaffected.

Follow-up from #123.