### PR TITLE
feat: install mergerfs-tools alongside mergerfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This role will do the following:
 * Install rclone (stefangweichinger.ansible_rclone) (optional)
 * Install Docker (geerlingguy.docker) (optional)
 * Install mergerfs
+  * Install [mergerfs-tools](https://github.com/trapexit/mergerfs-tools) (optional, enabled by default)
 * Install SnapRaid
 * Install btrfs
 * Wipe and setup disks
@@ -117,6 +118,8 @@ ___
 `install_rclone: true` — Installs rclone.
 
 `install_docker: true` — Installs and configures docker. Setting this or `configure_scrutiny` to true will run docker.
+
+`install_mergerfs_tools: true` — Installs [mergerfs-tools](https://github.com/trapexit/mergerfs-tools), optional utilities for managing data in a mergerfs pool.
 
 `configure_scrutiny: true` — Installs and configures [Scrutiny](https://github.com/Starosdev/scrutiny) in Docker for your disks.
 > [!NOTE]

--- a/roles/install_mergerfs/defaults/main.yml
+++ b/roles/install_mergerfs/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+install_mergerfs_tools: true
+mergerfs_tools_clone_dir: /tmp/mergerfs-tools

--- a/roles/install_mergerfs/handlers/main.yml
+++ b/roles/install_mergerfs/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Cleanup mergerfs-tools clone
+  ansible.builtin.file:
+    path: "{{ mergerfs_tools_clone_dir }}"
+    state: absent

--- a/roles/install_mergerfs/tasks/install_mergerfs_tools.yml
+++ b/roles/install_mergerfs/tasks/install_mergerfs_tools.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure git is installed
+  ansible.builtin.package:
+    name: git
+    state: present
+
+- name: Clone mergerfs-tools # noqa latest[git]
+  ansible.builtin.git:
+    repo: https://github.com/trapexit/mergerfs-tools.git
+    dest: "{{ mergerfs_tools_clone_dir }}"
+  notify: Cleanup mergerfs-tools clone
+
+- name: Discover mergerfs-tools files
+  ansible.builtin.find:
+    paths: "{{ mergerfs_tools_clone_dir }}/src"
+    file_type: file
+  register: mergerfs_tools_files
+
+- name: Install mergerfs-tools
+  ansible.builtin.command:
+    cmd: "install -v -m 0755 -o root -g root -D -C {{ item }} /usr/local/bin"
+    chdir: "{{ mergerfs_tools_clone_dir }}/src"
+  loop: "{{ mergerfs_tools_files.files | map(attribute='path') | map('basename') }}"
+  register: mergerfs_tools_install
+  changed_when: mergerfs_tools_install.stdout != ""

--- a/roles/install_mergerfs/tasks/main.yml
+++ b/roles/install_mergerfs/tasks/main.yml
@@ -60,3 +60,8 @@
           https://github.com/trapexit/mergerfs/releases/download/{{
             mergerfs_latest_version + '/' + mergerfs_pkg_prefix + mergerfs_latest_version + mergerfs_pkg_suffix }}
         state: present
+
+- name: Include mergerfs-tools install
+  ansible.builtin.include_tasks:
+    file: install_mergerfs_tools.yml
+  when: install_mergerfs_tools | default(true) | bool


### PR DESCRIPTION
Closes #141

Adds mergerfs-tools installation to the existing `install_mergerfs` role by cloning [trapexit/mergerfs-tools](https://github.com/trapexit/mergerfs-tools) and installing the 6 Python tools (`mergerfs.ctl`, `mergerfs.fsck`, `mergerfs.dup`, `mergerfs.dedup`, `mergerfs.balance`, `mergerfs.consolidate`) to `/usr/local/bin`.

Enabled by default. To opt out, set `install_mergerfs_tools: false` in `vars.yml`.

Thanks to @tigattack whose [ansible-role-mergerfs](https://github.com/tigattack/ansible-role-mergerfs) implementation this was based on.